### PR TITLE
Fix filenames of pdfs

### DIFF
--- a/script/convert_svg-emoji_to_pdf.py
+++ b/script/convert_svg-emoji_to_pdf.py
@@ -27,7 +27,7 @@ for filename in os.listdir(emojiPath):
 	processedCount += 1
 	if os.path.isfile(emojiPath+'/'+filename) and filename.endswith('.svg'):
 		hasSVG = True
-		cairosvg.svg2pdf(url=emojiPath+'/'+filename, write_to='../emoji_images/'+filename.split('.svg')[0]+'.pdf')
+		cairosvg.svg2pdf(url=emojiPath+'/'+filename, write_to='../emoji_images/'+filename.upper().split('.SVG')[0]+'.pdf')
 		sys.stdout.write('Processing: '+str(processedCount)+'\r')
 # check if SVGs were processed:
 if not hasSVG:


### PR DESCRIPTION
Latex expects the pdfs to be uppercased. This is a problem on
case senitive filesystems.

Cheers,
David